### PR TITLE
SEN-978: fix GOMEMORYLIMIT typo so the Go soft memory limit applies

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -221,7 +221,7 @@ EOL
     echo "FLORA_PROMETHEUSSERVER_ENABLED=false" >> "${ENV_PATH}"
     echo "FLORA_CONTAINERREPOSITORY_TRACKEDCONTAINERTYPE=docker" >> "${ENV_PATH}"
     echo "GOMAXPROCS=${GO_MAX_PROCS}" >> "${ENV_PATH}"
-    echo "GOMEMORYLIMIT=${GO_MEMORY_LIMIT}" >> "${ENV_PATH}"
+    echo "GOMEMLIMIT=${GO_MEMORY_LIMIT}" >> "${ENV_PATH}"
 
     log_success "Environment configuration completed"
 }


### PR DESCRIPTION
## Summary

`install.sh` writes the sensor env file with `GOMEMORYLIMIT=2048MiB`, but the Go runtime's env var is `GOMEMLIMIT` — and nothing else reads `GOMEMORYLIMIT` (the systemd unit execs the sensor binary directly, no wrapper). So the intended 2GiB soft limit has never taken effect: host sensors run with an unconstrained Go heap until the systemd `MemoryMax=4G` hard cgroup limit OOM-kills them, instead of the GC tightening around 2GiB.

The adjacent `GOMAXPROCS` line is spelled correctly and works — this was a typo.

One-word fix: `GOMEMORYLIMIT` → `GOMEMLIMIT`.

## Notes

- Composes cleanly with SEN-950 (`gomemlimit.Configure()` in the sensor treats a pre-set `GOMEMLIMIT` as an operator override and backs off).
- Existing installs won't heal on their own: `/etc/opt/groundcover/env.conf` is written at install time, so already-deployed hosts keep the dead var until the installer reruns.

Linear: [SEN-978](https://linear.app/groundcover/issue/SEN-978/host-installer-sets-gomemorylimit-instead-of-gomemlimit-go-soft-memory)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Go memory limit environment variable written during installation, so the sensor process now reads the expected setting.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->