### PR TITLE
SEN-979: install script overhaul (strict mode, staged upgrades, locking, full uninstall)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,22 @@
+name: lint
+
+on:
+  pull_request:
+    paths:
+      - "**.sh"
+  push:
+    branches: [main]
+    paths:
+      - "**.sh"
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - name: bash syntax check
+        run: bash -n install.sh
+      - name: shellcheck
+        run: shellcheck install.sh

--- a/install.sh
+++ b/install.sh
@@ -14,11 +14,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-BOLD="$(tput bold 2>/dev/null || printf '')"
-GREY="$(tput setaf 0 2>/dev/null || printf '')"
-RED="$(tput setaf 1 2>/dev/null || printf '')"
-GREEN="$(tput setaf 2 2>/dev/null || printf '')"
-NO_COLOR="$(tput sgr0 2>/dev/null || printf '')"
+if [[ -t 1 ]]; then
+    BOLD="$(tput bold 2>/dev/null || printf '')"
+    GREY="$(tput setaf 0 2>/dev/null || printf '')"
+    RED="$(tput setaf 1 2>/dev/null || printf '')"
+    GREEN="$(tput setaf 2 2>/dev/null || printf '')"
+    NO_COLOR="$(tput sgr0 2>/dev/null || printf '')"
+else
+    BOLD='' GREY='' RED='' GREEN='' NO_COLOR=''
+fi
 
 log_info() {
     printf '%s\n' "${BOLD}${GREY}>${NO_COLOR} $*"
@@ -32,6 +36,11 @@ log_success() {
    printf '%s\n' "${GREEN}✔${NO_COLOR} $*"
 }
 
+die() {
+    log_error "$*"
+    exit 1
+}
+
 printBanner() {
 cat << 'BANNER'
                                    _
@@ -39,7 +48,7 @@ cat << 'BANNER'
    / _` | '__/ _ \| | | | '_ \ / _` |/ __/ _ \ \ / / _ \ '__|
   | (_| | | | (_) | |_| | | | | (_| | (_| (_) \ V /  __/ |
    \__, |_|  \___/ \__,_|_| |_|\__,_|\___\___/ \_/ \___|_|
-   |___/                                       
+   |___/
          #NO TRADE-OFFS
 
 BANNER
@@ -54,6 +63,7 @@ SERVICE_NAME="${SENSOR_SERVICE_NAME:-${SENSOR_NAME}.service}"
 ENV_PATH="${SENSOR_ENV_PATH:-${ENV_DIR}/env.conf}"
 USER_CONFIG_PATH="${SENSOR_USER_CONFIG_PATH:-${ENV_DIR}/overrides.yaml}"
 RELEASE_URL_PREFIX="${SENSOR_RELEASE_URL_PREFIX:-https://groundcover.com/artifacts/latest/groundcover-sensor}"
+LOCK_FILE="${SENSOR_LOCK_FILE:-/run/${SENSOR_NAME}-install.lock}"
 
 GO_MAX_PROCS="${SENSOR_GO_MAX_PROCS:-2}"
 GO_MEMORY_LIMIT="${SENSOR_GO_MEMORY_LIMIT:-2048MiB}"
@@ -61,39 +71,96 @@ MAX_MEMORY_LIMIT="${SENSOR_MAX_MEMORY_LIMIT:-4G}"
 
 REQUIRED_VARS=("API_KEY" "GC_ENV_NAME" "GC_DOMAIN")
 
-set -e
+set -Eeuo pipefail
+trap 'log_error "Failed unexpectedly at line ${LINENO}: ${BASH_COMMAND}"' ERR
 
 usage() {
-    echo "Usage: $0 [install|uninstall]"
-    echo "  install   - Install or update the sensor"
-    echo "  uninstall - Remove the sensor and all its configurations"
-    exit 1
+    cat << EOF
+Usage: install.sh [install|uninstall]
+
+Commands:
+  install     Install or update the sensor
+  uninstall   Stop the sensor and remove all its files and configurations
+
+Required environment variables for install:
+  API_KEY      groundcover ingestion API key
+  GC_ENV_NAME  Environment name the sensor reports as
+  GC_DOMAIN    groundcover backend domain to send data to
+
+Optional overrides:
+  SENSOR_INSTALL_DIR       Install location (default: /opt/groundcover)
+  SENSOR_ENV_DIR           Configuration location (default: /etc/opt/groundcover)
+  SENSOR_GO_MAX_PROCS      Sensor GOMAXPROCS (default: ${GO_MAX_PROCS})
+  SENSOR_GO_MEMORY_LIMIT   Sensor GOMEMORYLIMIT (default: ${GO_MEMORY_LIMIT})
+  SENSOR_MAX_MEMORY_LIMIT  systemd MemoryMax (default: ${MAX_MEMORY_LIMIT})
+EOF
+    exit "${1:-1}"
+}
+
+checkPlatform() {
+    local os
+    os=$(uname -s)
+    if [[ "${os}" != "Linux" ]]; then
+        die "The groundcover sensor only supports Linux (detected: ${os})"
+    fi
 }
 
 checkRootPrivileges() {
     if [[ $EUID -ne 0 ]]; then
-       log_error "This script must be run with sudo or as root" 
-       exit 1
+       die "This script must be run with sudo or as root"
     fi
     log_info "Running with root privileges"
+}
+
+requireCommands() {
+    local cmd
+    for cmd in "$@"; do
+        if ! command -v "${cmd}" >/dev/null 2>&1; then
+            die "Required command '${cmd}' not found"
+        fi
+    done
+}
+
+acquireLock() {
+    exec 9> "${LOCK_FILE}"
+    if ! flock -n 9; then
+        die "Another sensor install/uninstall is already running"
+    fi
 }
 
 validateEnvVars() {
     log_info "Validating required environment variables"
     for var in "${REQUIRED_VARS[@]}"; do
         if [[ -z "${!var:-}" ]]; then
-            log_error "Environment variable $var must be set"
-            exit 1
+            die "Environment variable $var must be set"
         fi
     done
     log_success "All required environment variables are set"
 }
 
-checkCurl() {
-    if ! command -v curl >/dev/null 2>&1; then
-        log_error "curl not found"
-        exit 1
+httpGet() {
+    local fail_msg="$1" hint="$2"
+    shift 2
+
+    local http_code rc=0
+    http_code=$(curl -sS -w "%{http_code}" --connect-timeout 10 "$@") || rc=$?
+
+    if [[ ${rc} -ne 0 ]]; then
+        die "${fail_msg} (curl exit code ${rc})${hint}"
     fi
+
+    if [[ "${http_code}" != "200" ]]; then
+        die "${fail_msg} (HTTP ${http_code})${hint}"
+    fi
+}
+
+checkConnectivity() {
+    log_info "Checking connectivity to groundcover backend"
+
+    httpGet "Failed to connect to groundcover backend" ", please check your API key and contact support if the issue persists" \
+        --retry 2 --max-time 30 -o /dev/null -H "apikey: ${API_KEY}" "https://${GC_DOMAIN}/health/live"
+
+    log_success "Successfully verified connectivity to groundcover backend"
 }
 
 downloadRelease() {
@@ -110,23 +177,19 @@ downloadRelease() {
             tarball_arch="arm64"
             ;;
         *)
-            log_error "Unsupported architecture: ${arch}"
-            exit 1
+            die "Unsupported architecture: ${arch}"
             ;;
     esac
 
     local download_url="${RELEASE_URL_PREFIX}-${tarball_arch}"
     log_info "Downloading release from: ${download_url}"
-    
-    checkCurl
-    
-    http_code=$(curl -s -w "%{http_code}" -L -o "${TARBALL_NAME}" "${download_url}")
-        
-    if [[ "${http_code}" != "200" ]]; then
-        rm -f "${TARBALL_NAME}"
-        log_error "Failed to download release package"
-        exit 1
-    fi
+
+    WORK_DIR=$(mktemp -d)
+    trap 'rm -rf "${WORK_DIR}"' EXIT
+    TARBALL_PATH="${WORK_DIR}/${TARBALL_NAME}"
+
+    httpGet "Failed to download release package" "" \
+        -L --retry 3 --max-time 600 -o "${TARBALL_PATH}" "${download_url}"
 
     log_success "Successfully downloaded release package"
 }
@@ -134,67 +197,66 @@ downloadRelease() {
 prepareSensorConfig() {
     local config_path="${1}"
 
-    log_info "Preparing sensor configuration"
-
     if [[ ! -f "${config_path}" ]]; then
-        log_error "Configuration file '${config_path}' not found"
-        exit 1
+        die "Configuration file '${config_path}' not found"
     fi
 
     local placeholder_list
-    placeholder_list=$(grep -oE '<GC_PLACEHOLDER_[A-Z0-9_]+>' "${config_path}" | sort -u)
+    placeholder_list=$(grep -oE '<GC_PLACEHOLDER_[A-Z0-9_]+>' "${config_path}" | sort -u || true)
 
-    if [[ -z "$placeholder_list" ]]; then
-        log_info "No placeholders found in configuration"
+    if [[ -z "${placeholder_list}" ]]; then
         return 0
     fi
 
+    local content placeholder env_var_name
+    content=$(< "${config_path}")
+
     while IFS= read -r placeholder; do
-        local env_var_name
-        env_var_name=$(echo "$placeholder" | sed -E 's/^<GC_PLACEHOLDER_(.*)>$/GC_\1/')
+        env_var_name="${placeholder#<GC_PLACEHOLDER_}"
+        env_var_name="GC_${env_var_name%>}"
 
-        if [[ -n "${!env_var_name:-}" ]]; then
-            sed -i "s|${placeholder}|${!env_var_name}|g" "${config_path}"
-        else
-            log_error "Environment variable '$env_var_name' not set"
-            exit 1
+        if [[ -z "${!env_var_name:-}" ]]; then
+            die "Environment variable '${env_var_name}' not set"
         fi
-    done <<< "$placeholder_list"
 
-    log_success "Configuration setup completed successfully"
-    return 0
+        content=${content//"${placeholder}"/${!env_var_name}}
+    done <<< "${placeholder_list}"
+
+    printf '%s\n' "${content}" > "${config_path}"
 }
 
 prepareSetup() {
-    local CONFIG_PATH="${INSTALL_DIR}/config/config.yaml"
-    local LOGS_SCRAPE_CONFIG_PATH="${INSTALL_DIR}/${SCRAPE_CONFIG_DIR}/logs-scrape-config.yaml"
-    local METRICS_SCRAPE_CONFIG_PATH="${INSTALL_DIR}/${SCRAPE_CONFIG_DIR}/metrics-scrape-config.yaml"
+    log_info "Extracting sensor package"
 
-    log_info "Starting sensor package setup"
+    STAGING_DIR="${WORK_DIR}/package"
+    mkdir -p "${STAGING_DIR}"
+    tar -xzf "${TARBALL_PATH}" -C "${STAGING_DIR}"
 
-    if [[ ! -f "${TARBALL_NAME}" ]]; then
-        log_error "Tarball ${TARBALL_NAME} not found in the current directory"
-        exit 1
+    if [[ ! -f "${STAGING_DIR}/${SENSOR_NAME}" ]]; then
+        die "Executable binary ${SENSOR_NAME} not found in package"
+    fi
+    chmod +x "${STAGING_DIR}/${SENSOR_NAME}"
+
+    log_info "Preparing sensor configuration"
+    prepareSensorConfig "${STAGING_DIR}/config/config.yaml"
+    prepareSensorConfig "${STAGING_DIR}/${SCRAPE_CONFIG_DIR}/logs-scrape-config.yaml"
+    prepareSensorConfig "${STAGING_DIR}/${SCRAPE_CONFIG_DIR}/metrics-scrape-config.yaml"
+
+    log_success "Sensor package prepared"
+}
+
+deploySensorFiles() {
+    if systemctl is-active --quiet "${SERVICE_NAME}"; then
+        log_info "Stopping running sensor service before upgrade"
+        systemctl stop "${SERVICE_NAME}"
     fi
 
-    log_info "Creating installation directory: ${INSTALL_DIR}"
+    log_info "Installing sensor package to ${INSTALL_DIR}"
+    rm -rf "${INSTALL_DIR}"
     mkdir -p "${INSTALL_DIR}"
-
-    log_info "Extracting sensor package"
-    tar -xzf "${TARBALL_NAME}" -C "${INSTALL_DIR}"
+    cp -a "${STAGING_DIR}/." "${INSTALL_DIR}/"
 
     BINARY_PATH="${INSTALL_DIR}/${SENSOR_NAME}"
-    if [[ ! -x "${BINARY_PATH}" ]]; then
-        log_error "Executable binary ${SENSOR_NAME} not found"
-        exit 1
-    fi
-
-    log_info "Setting permissions for installation directory"
-    chmod +x "${BINARY_PATH}"
-
-    prepareSensorConfig "${CONFIG_PATH}"
-    prepareSensorConfig "${LOGS_SCRAPE_CONFIG_PATH}"
-    prepareSensorConfig "${METRICS_SCRAPE_CONFIG_PATH}"
 }
 
 setupServiceEnv() {
@@ -216,12 +278,14 @@ EOL
     fi
 
     log_info "Writing environment variables"
-    echo "API_KEY=$API_KEY" >> "${ENV_PATH}"
-    echo "CONFIG_OVERRIDES_PATH=${USER_CONFIG_PATH}" >> "${ENV_PATH}"
-    echo "FLORA_PROMETHEUSSERVER_ENABLED=false" >> "${ENV_PATH}"
-    echo "FLORA_CONTAINERREPOSITORY_TRACKEDCONTAINERTYPE=docker" >> "${ENV_PATH}"
-    echo "GOMAXPROCS=${GO_MAX_PROCS}" >> "${ENV_PATH}"
-    echo "GOMEMORYLIMIT=${GO_MEMORY_LIMIT}" >> "${ENV_PATH}"
+    cat > "${ENV_PATH}" << EOL
+API_KEY=${API_KEY}
+CONFIG_OVERRIDES_PATH=${USER_CONFIG_PATH}
+FLORA_PROMETHEUSSERVER_ENABLED=false
+FLORA_CONTAINERREPOSITORY_TRACKEDCONTAINERTYPE=docker
+GOMAXPROCS=${GO_MAX_PROCS}
+GOMEMORYLIMIT=${GO_MEMORY_LIMIT}
+EOL
 
     log_success "Environment configuration completed"
 }
@@ -245,7 +309,7 @@ Restart=on-failure
 [Install]
 WantedBy=multi-user.target
 EOL
-    
+
     setupServiceEnv
     log_success "Sensor service configuration completed"
 }
@@ -255,25 +319,32 @@ startService() {
     systemctl daemon-reload
     systemctl enable "${SERVICE_NAME}"
 
-    if systemctl is-active --quiet "${SERVICE_NAME}"; then
-        log_info "Stopping existing service"
-        systemctl stop "${SERVICE_NAME}"
-    fi
-    
     if ! systemctl start "${SERVICE_NAME}"; then
         log_error "Service failed to start. Recent logs:"
-        journalctl -u "${SERVICE_NAME}" --no-pager -n 50
+        journalctl -u "${SERVICE_NAME}" --no-pager -n 50 || true
         exit 1
     fi
 
-    log_success "groundcover sensor service installation complete!"
+    sleep 2
 
-    systemctl is-active --quiet "${SERVICE_NAME}" && 
-        log_success "groundcover sensor is up and running" || 
-        log_error "groundcover sensor failed to start"
+    if ! systemctl is-active --quiet "${SERVICE_NAME}"; then
+        log_error "groundcover sensor failed to stay running. Recent logs:"
+        journalctl -u "${SERVICE_NAME}" --no-pager -n 50 || true
+        exit 1
+    fi
 
+    log_success "groundcover sensor is up and running"
     log_info "To check sensor status: systemctl status ${SERVICE_NAME}"
     log_info "To view sensor logs: journalctl -u ${SERVICE_NAME}"
+}
+
+removePath() {
+    local path="$1" description="$2"
+
+    if [[ -e "${path}" ]]; then
+        log_info "Removing ${description}"
+        rm -rfv "${path}"
+    fi
 }
 
 uninstallSensor() {
@@ -283,42 +354,21 @@ uninstallSensor() {
         log_info "Stopping sensor service"
         systemctl stop "${SERVICE_NAME}"
     fi
-    
-    if systemctl is-enabled --quiet "${SERVICE_NAME}"; then
+
+    if systemctl is-enabled --quiet "${SERVICE_NAME}" 2>/dev/null; then
         log_info "Disabling sensor service"
         systemctl disable "${SERVICE_NAME}"
     fi
 
-    if [[ -f "/etc/systemd/system/${SERVICE_NAME}" ]]; then
-        log_info "Removing service file"
-        rm -fv "/etc/systemd/system/${SERVICE_NAME}"
-        systemctl daemon-reload
-    fi
+    systemctl reset-failed "${SERVICE_NAME}" 2>/dev/null || true
 
-    if [[ -d "${INSTALL_DIR}" ]]; then
-        log_info "Removing installation directory"
-        rm -rfv "${INSTALL_DIR}"
-    fi
+    removePath "/etc/systemd/system/${SERVICE_NAME}" "service file"
+    systemctl daemon-reload
+
+    removePath "${INSTALL_DIR}" "installation directory"
+    removePath "${ENV_DIR}" "environment configuration directory"
 
     log_success "Uninstallation completed successfully"
-
-}
-
-checkConnectivity() {
-    log_info "Checking connectivity to groundcover backend"
-    local health_url="https://${GC_DOMAIN}/health/live"
-    
-    checkCurl
-
-    local http_code
-    http_code=$(curl -s -w "%{http_code}" -o /dev/null -H "apikey: ${API_KEY}" "${health_url}")
-    
-    if [[ "${http_code}" != "200" ]]; then
-        log_error "Failed to connect to groundcover backend (HTTP ${http_code}), please check your API key and contact support if the issue persists"
-        exit 1
-    fi
-
-    log_success "Successfully verified connectivity to groundcover backend"
 }
 
 install() {
@@ -327,6 +377,7 @@ install() {
     checkConnectivity
     downloadRelease
     prepareSetup
+    deploySensorFiles
     installSensor
     startService
 }
@@ -337,20 +388,21 @@ uninstall() {
 }
 
 main() {
-    checkRootPrivileges
-    
-    case "$1" in
-        "install")
-            install
+    case "${1:-}" in
+        install|uninstall)
+            checkPlatform
+            checkRootPrivileges
+            requireCommands curl tar systemctl journalctl mktemp flock
+            acquireLock
+            "$1"
             ;;
-        "uninstall")
-            uninstall
+        -h|--help|help)
+            usage 0
             ;;
         *)
-            usage
+            usage 1
             ;;
     esac
-
 }
 
-main "$@" || exit 1
+main "$@"


### PR DESCRIPTION
## Summary

Follow-up to #7 — started as a cleanup pass over `install.sh`, grew into a full overhaul. The install command interface (`curl | sudo env ... bash -s -- install`) is unchanged.

### Correctness fixes
- **`set -e` was unintentionally disabled for the whole script.** The entrypoint was `main "$@" || exit 1`; bash suppresses errexit inside anything called from the left side of `||`. Now: direct `main "$@"` plus full strict mode — `set -Eeuo pipefail` with an ERR trap that reports the failing line and command for anything unchecked.
- **A sensor that crashed right after start reported success.** `startService` logged "failed to start" via the `A && B || C` chain but still exited 0. Now it settles 2s, re-checks `is-active`, dumps the last 50 journal lines, and exits 1.
- **`uninstall` now performs a full cleanup** — previously left `/etc/opt/groundcover` (`env.conf` with the API key, `overrides.yaml`) behind despite the usage text promising removal; also runs `reset-failed`.
- **Upgrades no longer swap files under a running sensor.** The package is extracted and placeholder-rendered in a staging dir first; the service is stopped before the old install dir is replaced, then started. `overrides.yaml` survives upgrades (verified).

### Robustness
- **Tarball downloads into a `mktemp -d` workdir with a `trap ... EXIT`** — no dependence on the invoking directory, cleaned up on every exit path.
- **Shared `httpGet` helper**: curl exit code reported on transport failures (6 = DNS, 7 = refused, 28 = timeout), HTTP status on non-200; `--connect-timeout`/`--max-time`/`--retry` everywhere (a black-holed connection previously hung forever); `-sS` so curl's own reason surfaces.
- **`flock`-based lock** — concurrent install/uninstall runs are refused instead of racing.
- **Placeholder rendering moved from `sed -i` to pure-bash replacement** — immune to delimiter/metacharacter injection from env values, no subprocess per placeholder.
- **Preflight checks**: Linux-only gate with a clear message, required-command check (`curl`, `tar`, `systemctl`, `flock`, ...), root check.
- **`--help`/usage** documents required env vars and all `SENSOR_*` overrides.
- Colors suppressed when stdout isn't a tty; `die()`/`removePath()` helpers; env file written via heredoc. **shellcheck fully clean**, enforced by a new CI lint workflow.

### Tested
Static: `bash -n`, shellcheck (zero findings), truncated-stream (`curl | bash` partial download) safety, placeholder unit tests incl. sed-hostile values (`| & $() "`).

E2E in a systemd (Ubuntu 24.04) container with a fake package server and a TLS health endpoint — **25/25 pass**: fresh install, placeholder substitution, env.conf perms, upgrade (service restarted, overrides preserved), concurrent-run lock refusal, piped `bash -s -- install`, crash-looping binary → non-zero exit with journal excerpt, full uninstall (dirs + unit gone), non-root refusal, 404 download, DNS-failure reporting.

### Not included (needs artifact-pipeline work)
- Checksum verification — no `.sha256` is published next to the artifacts today (verified 404).
- Version pinning — artifacts only exist under `latest/`.

Linear: [SEN-979](https://linear.app/groundcover/issue/SEN-979)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved installer reliability with stronger preflight checks, safer downloads, and protection against concurrent runs.
  * Added clearer failure reporting and progress/log output when installation or startup fails.

* **Bug Fixes**
  * Fixed upgrade flow to stage files safely before replacing an existing installation.
  * Improved service startup handling so failed launches are detected and recent logs are shown.
  * Uninstall now removes additional leftover configuration files.

* **Chores**
  * Added automated shell syntax and lint checks for shell scripts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->